### PR TITLE
openwrt: manage UCI config with salt.states.openwrt

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ proxy:
 
 openwrt_config:
   config:
-    system.ntp.server: 10.33.0.1
+    system.ntp.server: a.b.c.d
 ```
 
 Password should be encrypted with GPG salt-master public key for security reasons

--- a/README.md
+++ b/README.md
@@ -1,8 +1,50 @@
 # salt_openwrt
 Saltstack openwrt proxy minion
 
-Only works when 
+Only works when multiprocessing is set in /etc/salt/proxy as follow:
+```
+multiprocessing: False
+```
 
-  multiprocessing: False
+## Example
 
-is set in /etc/salt/proxy
+### Pillar config
+
+```yaml
+---
+
+proxy:
+  proxytype: openwrt
+  host: a.b.c.d
+  username: root
+  password: SuperPassword!
+
+openwrt_config:
+  config:
+    system.ntp.server: 10.33.0.1
+```
+
+Password should be encrypted with GPG salt-master public key for security reasons
+
+
+### Sample SLS state
+
+```yaml
+
+---
+
+{% set openwrt_config = salt['pillar.get']('openwrt_config', default={}) %}
+
+{% for c in openwrt_config.config|default({}) %}
+openwrt-config-{{loop.index}}:
+  openwrt.config_set:
+    - name: {{c}}
+    - value: {{openwrt_config.config[c]}}
+    - watch_in:
+        - openwrt-reload
+{% endfor %}
+
+openwrt-reload:
+  module.wait:
+    - name: openwrt.config_reload
+```

--- a/_proxy/openwrt.py
+++ b/_proxy/openwrt.py
@@ -48,7 +48,7 @@ def init(opts):
             password=opts['proxy']['password'],
             key_accept=opts['proxy'].get('key_accept', False),
             ssh_args=opts['proxy'].get('ssh_args', ''),
-            prompt='root.+#')
+            prompt='root@.+# $')
         log.info('SSH Connection established.')
         out, err = DETAILS['server'].sendline('id')
         DETAILS['initialized'] = True
@@ -241,6 +241,7 @@ def ssh_file_content(filename):
     '''
     data, _ = ssh_cmd('cat %s' % (filename,))
     return data
+
 
 def shutdown(opts):
     '''

--- a/_proxy/openwrt.py
+++ b/_proxy/openwrt.py
@@ -55,7 +55,7 @@ def ping():
     Required.
     Ping the device on the other end of the connection
     '''
-    ssh_oneshot('echo 1234') == '1234'
+    return ssh_oneshot('echo 1234') == '1234'
     
 def grains(**kwargs):
     '''

--- a/_proxy/openwrt.py
+++ b/_proxy/openwrt.py
@@ -171,8 +171,8 @@ def _proxy_connect():
             try:        
                 DETAILS['server'] = SSHConnection(
                     host=DETAILS['proxy']['host'],
-                    username=DETAILS['proxy']['username'],
-                    password=DETAILS['proxy']['password'],
+                    username=DETAILS['proxy']('username', 'root'),
+                    password=DETAILS['proxy']('password', ''),
                     key_accept=DETAILS['proxy'].get('key_accept', False),
                     ssh_args=DETAILS['proxy'].get('ssh_args', ''),
                     prompt='root@.+#'

--- a/_proxy/openwrt.py
+++ b/_proxy/openwrt.py
@@ -174,8 +174,8 @@ def _proxy_connect():
             try:        
                 DETAILS['server'] = SSHConnection(
                     host=DETAILS['proxy']['host'],
-                    username=DETAILS['proxy']('username', 'root'),
-                    password=DETAILS['proxy']('password', ''),
+                    username=DETAILS['proxy'].get('username', 'root'),
+                    password=DETAILS['proxy'].get('password', ''),
                     key_accept=DETAILS['proxy'].get('key_accept', False),
                     ssh_args=DETAILS['proxy'].get('ssh_args', ''),
                     prompt='root@.+#'

--- a/_proxy/openwrt.py
+++ b/_proxy/openwrt.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 # Import Python Libs
 import logging
 import re
+import time
 
 # Import Salt Libs
 import salt.exceptions
@@ -165,8 +166,10 @@ def _proxy_connect():
     retry_conn = 0
     
     while retry_conn < DETAILS['proxy'].get('conn_retry', 3):
+        if retry_conn > 0:
+            time.sleep(1)
+        
         retry_conn += 1
-
         if not DETAILS.get('server'):
             try:        
                 DETAILS['server'] = SSHConnection(

--- a/_proxy/openwrt.py
+++ b/_proxy/openwrt.py
@@ -164,17 +164,17 @@ def grains_refresh(**kwargs):
 def _proxy_connect():
     retry_conn = 0
     
-    while retry_conn < DETAILS['opts']['proxy'].get('conn_retry', 3):
+    while retry_conn < DETAILS['proxy'].get('conn_retry', 3):
         retry_conn += 1
 
         if not DETAILS.get('server'):
             try:        
                 DETAILS['server'] = SSHConnection(
-                    host=DETAILS['opts']['proxy']['host'],
-                    username=DETAILS['opts']['proxy']['username'],
-                    password=DETAILS['opts']['proxy']['password'],
-                    key_accept=DETAILS['opts']['proxy'].get('key_accept', False),
-                    ssh_args=DETAILS['opts']['proxy'].get('ssh_args', ''),
+                    host=DETAILS['proxy']['host'],
+                    username=DETAILS['proxy']['username'],
+                    password=DETAILS['proxy']['password'],
+                    key_accept=DETAILS['proxy'].get('key_accept', False),
+                    ssh_args=DETAILS['proxy'].get('ssh_args', ''),
                     prompt='root@.+# $'
                 )
                 log.info('SSH Connection established.')

--- a/_proxy/openwrt.py
+++ b/_proxy/openwrt.py
@@ -175,7 +175,7 @@ def _proxy_connect():
                     password=DETAILS['proxy']['password'],
                     key_accept=DETAILS['proxy'].get('key_accept', False),
                     ssh_args=DETAILS['proxy'].get('ssh_args', ''),
-                    prompt='root@.+# $'
+                    prompt='root@.+#'
                 )
                 log.info('SSH Connection established.')
             except TerminalException as e:
@@ -183,6 +183,7 @@ def _proxy_connect():
                 continue
     
         out, err = DETAILS['server'].sendline('echo 1234')
+        out = "\n".join(out.split('\n')[1:-1])
         if out != '1234':
             DETAILS['server'] = None
             continue

--- a/_states/openwrt.py
+++ b/_states/openwrt.py
@@ -30,11 +30,6 @@ def config_set(name=None, value=None):
     value = str(value)
 
     openwrt_ret  = __salt__["openwrt.config_get"](name)
-    if openwrt_ret == False:
-        ret["result"] = False
-        ret["comment"] = "UCI key {} does not exist".format(name)
-        return ret
-
     if openwrt_ret == value:
         ret["result"] = True
         ret["comment"] = "UCI key {} already set to {}".format(name, value)

--- a/_states/openwrt.py
+++ b/_states/openwrt.py
@@ -1,0 +1,56 @@
+# Import Python Libs
+from __future__ import absolute_import, print_function, unicode_literals
+
+
+def config_set(name=None, value=None):
+    """
+    Manage openwrt UCI named key config
+    If value is different, set config value and commit config
+
+    name
+        UCI key to manage
+
+    value
+        Set UCI key to value
+    """
+
+    ret = {"name": name, "changes": {}, "result": False, "comment": ""}
+
+    if name is None:
+        ret["result"] = False
+        ret["comment"] = "Must provide name to openwrt.config_set"
+        return ret
+
+    if value is None:
+        ret["result"] = False
+        ret["comment"] = "Must provide value to openwrt.config_set"
+        return ret
+
+    # openwrt: UCI values are strings
+    value = str(value)
+
+    openwrt_ret  = __salt__["openwrt.config_get"](name)
+    if openwrt_ret == False:
+        ret["result"] = False
+        ret["comment"] = "UCI key {} does not exist".format(name)
+        return ret
+
+    if openwrt_ret == value:
+        ret["result"] = True
+        ret["comment"] = "UCI key {} already set to {}".format(name, value)
+        return ret
+
+    if __opts__["test"]:
+        ret["result"] = None
+        ret["comment"] = "UCI key {} will change to {}".format(name, value)
+        return ret
+
+    openwrt_ret = __salt__["openwrt.config_set"](name, value)
+    if openwrt_ret == True:
+        ret["result"] = True
+        ret["changes"] = {"value": "updated"}
+        ret["comment"] = "UCI key {} changed to {}".format(name, value)
+        return ret
+
+    ret["comment"] = "Failed to change UCI key {} to {}".format(name, value)
+    return ret


### PR DESCRIPTION
Hello

Thanks for the work (you and original author).

* _states: openwrt binding
* _modules:
   - add UCI config get/set
   - fix network reload/restart
* _proxy: on long output, we need to parse output until the last shell prompt